### PR TITLE
Remove incorrect comment in nginx config

### DIFF
--- a/helm/osmcha/values.yaml
+++ b/helm/osmcha/values.yaml
@@ -118,7 +118,6 @@ app:
 
             location / {
               root /assets;
-              # checks for static file, if not found proxy to app
               try_files $uri $uri/ /index.html;
             }
           }


### PR DESCRIPTION
Just cleaning up a misleading comment I noticed while investigating how nginx is routing requests to the backend. This comment was probably copy-pasted from `osmcha-django` which has its own `nginx.conf` file for local development that works a bit differently from the version deployed to prod.
