### PR TITLE
Increase node heap size for adiff service

### DIFF
--- a/helm/osmcha/templates/adiff-service-worker.yaml
+++ b/helm/osmcha/templates/adiff-service-worker.yaml
@@ -44,3 +44,5 @@ spec:
               value: {{ .Values.adiff_service.redis_url }}
             - name: NumberOfWorkers
               value: {{ .Values.adiff_service.worker_count | quote }}
+            - name: NODE_OPTIONS
+              value: --max-old-space-size=8192


### PR DESCRIPTION
Trying to fix this issue that appeared today:

```
λ kubectl logs osmcha-adiff-service-worker-66d4ff6645-66xjx
yarn run v1.22.19
$ node ./update.js
-- STARTING PROCESS AT Thu Jan 02 2025 18:44:34 GMT+0000
(node:28) NOTE: The AWS SDK for JavaScript (v2) will enter maintenance mode
on September 8, 2024 and reach end-of-support on September 8, 2025.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check blog post at https://a.co/cUPnyil
(Use `node --trace-warnings ...` to show where the warning was created)
Queueing replication files from 6391217 to 6413126 to process.

<--- Last few GCs --->

[28:0x7fe6d04530c0]    41485 ms: Mark-sweep (reduce) 2038.5 (2083.8) -> 2037.8 (2084.3) MB, 2033.5 / 0.0 ms  (average mu = 0.160, current mu = 0.002) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
error Command failed with signal "SIGABRT".
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```