### PR TITLE
Increase thread count per gunicorn worker

### DIFF
--- a/helm/osmcha/templates/app.yaml
+++ b/helm/osmcha/templates/app.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
       - name: osmcha-api
         image: {{ .Values.app.api.image.repository }}:{{ .Values.app.api.image.tag }}
+        args: ["gunicorn", "config.wsgi", "-b", "0.0.0.0:5000", "--access-logfile", "-", "--timeout", "120", "--workers", "4", "--threads", "16"]
         resources:
           {{- toYaml .Values.app.api.resources | nindent 10 }}
         env:
@@ -71,8 +72,6 @@ spec:
           value: "False"
         - name: DJANGO_ENABLE_CHANGESET_COMMENTS
           value: "True"
-        - name: WEB_CONCURRENCY
-          value: "5"
         ports:
         - containerPort: 5000
         volumeMounts:


### PR DESCRIPTION
Instead of running single-threaded gunicorn worker processes, this PR runs 16 threads per worker process. The threads are limited by the Python GIL, so they can't execute in parallel, but this should still increase the number of database queries that can be pending concurrently (since each query ties up the thread that's spawned from until it completes).

This switches gunicorn from using "sync" workers (the default) to "gthread" workers (the default when `--threads` is greater than one). These are entirely different worker implementations, so this change carries some risk. I will monitor it carefully after deploying.