### PR TITLE
Revert "Increase thread count per gunicorn worker"

### DIFF
--- a/helm/osmcha/templates/app.yaml
+++ b/helm/osmcha/templates/app.yaml
@@ -30,7 +30,6 @@ spec:
       containers:
       - name: osmcha-api
         image: {{ .Values.app.api.image.repository }}:{{ .Values.app.api.image.tag }}
-        args: ["gunicorn", "config.wsgi", "-b", "0.0.0.0:5000", "--access-logfile", "-", "--timeout", "120", "--workers", "4", "--threads", "16"]
         resources:
           {{- toYaml .Values.app.api.resources | nindent 10 }}
         env:
@@ -72,6 +71,8 @@ spec:
           value: "False"
         - name: DJANGO_ENABLE_CHANGESET_COMMENTS
           value: "True"
+        - name: WEB_CONCURRENCY
+          value: "5"
         ports:
         - containerPort: 5000
         volumeMounts:


### PR DESCRIPTION
Reverts OSMCha/osmcha-deploy#52

Causing a 504 Gateway Timeout error. Container is up but not receiving traffic (except k8s healthchecks).