### PR TITLE
Upgrade Kubernetes to 1.30

### DIFF
--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -48,7 +48,7 @@ module "eks" {
   version = "19.19.0"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.29"
+  cluster_version = "1.30"
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets


### PR DESCRIPTION
This is to avoid incurring additional monthly costs when Amazon EKS moves 1.29 into extended maintenance pricing on 2025-03-23