### PR TITLE
Use three t3.large k8s nodes instead of two t3.xlarge nodes

### DIFF
--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -68,11 +68,11 @@ module "eks" {
     regular = {
       name = "regular"
 
-      instance_types = ["t3.xlarge"]
+      instance_types = ["t3.large"]
 
       min_size     = 1
-      max_size     = 2
-      desired_size = 1
+      max_size     = 3
+      desired_size = 3
 
       # Needed by the aws-ebs-csi-driver
       iam_role_additional_policies = {

--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -65,20 +65,6 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
-    default = {
-      name = "default"
-
-      instance_types = ["t3.small"]
-
-      min_size     = 0
-      max_size     = 1
-
-      # Needed by the aws-ebs-csi-driver
-      iam_role_additional_policies = {
-        AmazonEBSCSIDriverPolicy = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-      }
-    }
-
     regular = {
       name = "regular"
 


### PR DESCRIPTION
There's a problem right now where Redis requires an EBS volume that is in the us-east-1c AZ. With two nodes but three AZs in us-east, redeploying the cluster (e.g. to do a k8s version upgrade) can result in there being no node in us-east-1c, which means k8s won't schedule the Redis pod at all.

Fixing this the "right" way (by constraining node deployment so that at least one node was in us-east-1c) looked difficult because it's hidden under the abstraction of the terraform-aws-eks module. So instead I'm just changing the compute distribution to run three t3.large nodes instead of two t3.xlarge. This should still be enough capacity for the application and will I think guarantee that at least one node is placed in us-east-1c.