### PR TITLE
Revert "Use three t3.large k8s nodes instead of two t3.xlarge nodes (#62)"

### DIFF
--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -65,14 +65,28 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
+    default = {
+      name = "default"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 0
+      max_size     = 1
+
+      # Needed by the aws-ebs-csi-driver
+      iam_role_additional_policies = {
+        AmazonEBSCSIDriverPolicy = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+      }
+    }
+
     regular = {
       name = "regular"
 
-      instance_types = ["t3.large"]
+      instance_types = ["t3.xlarge"]
 
       min_size     = 1
-      max_size     = 3
-      desired_size = 3
+      max_size     = 2
+      desired_size = 1
 
       # Needed by the aws-ebs-csi-driver
       iam_role_additional_policies = {


### PR DESCRIPTION
This reverts commit bff7aba06f29656d714837ed77e1ba3bd32ad1aa.

Under that configuration, the `app` pod failed to be scheduled because it requested more CPUs than were available after other pods had been placed.

Changing the configured CPU requests in Helm might fix this, but to restore service faster I'm just going to revert for now.