### PR TITLE
Skip uploading tag changes in osm-adiff-service

### DIFF
--- a/helm/osmcha/templates/adiff-service-worker.yaml
+++ b/helm/osmcha/templates/adiff-service-worker.yaml
@@ -35,11 +35,14 @@ spec:
                 secretKeyRef:
                   name: osmcha-real-changesets-credentials
                   key: secret_key
-            - name: OsmchaAdminToken
-              valueFrom:
-                secretKeyRef:
-                  name: osmcha-admin-token
-                  key: osmcha_admin_token
+            # NOTE: this is intentionally disabled; the job of uploading tag changes
+            # is now performed by https://github.com/OSMCha/changeset-adiffs-worker
+            # Omitting this token causes osm-adiff-service to skip uploading tag changes.
+            # - name: OsmchaAdminToken
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: osmcha-admin-token
+            #       key: osmcha_admin_token
             - name: RedisServer
               value: {{ .Values.adiff_service.redis_url }}
             - name: NumberOfWorkers

--- a/helm/osmcha/values.yaml
+++ b/helm/osmcha/values.yaml
@@ -42,6 +42,6 @@ adiff_service:
   replicas: 1
   image:
     repository: ghcr.io/osmcha/osm-adiff-service
-    tag: b0b2bcaf1d7428e48146c70ea80e129fcd864686
+    tag: df2ca6df21fe1b7058875e3316f2bc45221a8bf0
   redis_url: redis://redis-master:6379
   worker_count: "14"


### PR DESCRIPTION
The job of uploading tag changes is now performed by this worker: https://github.com/OSMCha/changeset-adiffs-worker, so we can remove that responsibility from the osm-adiff-service (as currently deployed, it's just redoing the work of changeset-adiffs-worker, only several days delayed).

Note that the previously deployed version of osm-adiff-service (`b0b2bcaf`) was not the most recent commit of that repo. So this deploy will contain both my recent changes to allow for skipping the tag-changes upload ([`df2ca6df`](https://github.com/OSMCha/osm-adiff-service/commit/df2ca6df21fe1b7058875e3316f2bc45221a8bf0)) as well as some refactoring I did a few months ago which was never deployed ([`fb4beab5`](https://github.com/OSMCha/osm-adiff-service/commit/fb4beab5b6bc52f5794caa18858a120150a72feb)). I tested those changes thoroughly at the time so I'm not concerned about deploying them now, but I'll keep an eye on the osm-adiff-service logs after deploying this just to be safe.