### PR TITLE
Bump osm-adiff-service version

### DIFF
--- a/helm/osmcha/values.yaml
+++ b/helm/osmcha/values.yaml
@@ -42,6 +42,6 @@ adiff_service:
   replicas: 1
   image:
     repository: ghcr.io/osmcha/osm-adiff-service
-    tag: df2ca6df21fe1b7058875e3316f2bc45221a8bf0
+    tag: b8f1228d0f8711d1c1185f003488c67db48b2e76
   redis_url: redis://redis-master:6379
   worker_count: "14"


### PR DESCRIPTION
Deploys the fix for https://github.com/OSMCha/osm-adiff-service/issues/23