### PR TITLE
Bump kubernetes version to 1.31

### DIFF
--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -48,7 +48,7 @@ module "eks" {
   version = "19.19.0"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets


### PR DESCRIPTION
AWS is moving Kubernetes 1.30 to extended support mode (which incurs extra costs) on July 22. This upgrade should hopefully have no effect on the operation of OSMCha.