### PR TITLE
Bump kubernetes version to 1.32

### DIFF
--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -48,7 +48,7 @@ module "eks" {
   version = "19.19.0"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets


### PR DESCRIPTION
#73 seemed to go well, so let's bump another version while we're at it.